### PR TITLE
Improve readability across inspectors and GUI

### DIFF
--- a/fbx_analyzer/inspectors/scene_graph.py
+++ b/fbx_analyzer/inspectors/scene_graph.py
@@ -2,55 +2,61 @@
 
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict, Tuple
 
 from ..core import sdk
 from ..core.analyzer import SceneContext, SceneInspector
 from ..models import SceneNode
+from ..utils import double3_to_tuple
 
 
 class SceneGraphInspector(SceneInspector):
+    """Capture the entire scene hierarchy as editable ``SceneNode`` models."""
+
     id = "scene_graph"
 
     def collect(self, context: SceneContext) -> SceneNode:
         fbx, _ = sdk.import_fbx_module()
 
-        def build(node, path: Tuple[int, ...]) -> SceneNode:
+        def build(node, path: Tuple[int, ...]) -> SceneNode:  # type: ignore[valid-type]
             attribute = node.GetNodeAttribute()
             attribute_type = attribute.GetTypeName() if attribute else "None"
             attribute_class = attribute.__class__.__name__ if attribute else "(NoAttribute)"
-
-            def to_tuple(vector):
-                return (float(vector[0]), float(vector[1]), float(vector[2]))
-
-            properties: Dict[str, str] = {}
-            prop = node.GetFirstProperty()
-            while prop.IsValid():
-                try:
-                    if prop.GetFlag(fbx.FbxPropertyFlags.eUserDefined):
-                        properties[prop.GetName()] = str(prop.Get())
-                except Exception:
-                    pass
-                prop = node.GetNextProperty(prop)
 
             scene_node = SceneNode(
                 name=node.GetName() or f"Node_{node.GetUniqueID()}",
                 attribute_type=attribute_type,
                 attribute_class=attribute_class,
-                translation=to_tuple(node.LclTranslation.Get()),
-                rotation=to_tuple(node.LclRotation.Get()),
-                scaling=to_tuple(node.LclScaling.Get()),
+                translation=double3_to_tuple(node.LclTranslation.Get()),
+                rotation=double3_to_tuple(node.LclRotation.Get()),
+                scaling=double3_to_tuple(node.LclScaling.Get()),
                 child_count=node.GetChildCount(),
                 uid=node.GetUniqueID(),
                 parent_uid=node.GetParent().GetUniqueID() if node.GetParent() else None,
                 original_path=path,
-                properties=properties,
+                properties=_collect_user_properties(node, fbx),
             )
 
             for idx in range(node.GetChildCount()):
-                scene_node.children.append(build(node.GetChild(idx), path + (idx,)))
+                child_path = path + (idx,)
+                scene_node.children.append(build(node.GetChild(idx), child_path))
 
             scene_node.child_count = len(scene_node.children)
             return scene_node
 
         return build(context.root_node, ())
+
+
+def _collect_user_properties(node, fbx_module) -> Dict[str, str]:  # type: ignore[valid-type]
+    """Gather user-defined properties from an FBX node."""
+
+    properties: Dict[str, str] = {}
+    prop = node.GetFirstProperty()
+    while prop.IsValid():
+        try:
+            if prop.GetFlag(fbx_module.FbxPropertyFlags.eUserDefined):
+                properties[prop.GetName()] = str(prop.Get())
+        except Exception:
+            pass
+        prop = node.GetNextProperty(prop)
+    return properties

--- a/fbx_analyzer/utils.py
+++ b/fbx_analyzer/utils.py
@@ -1,0 +1,46 @@
+"""Shared helper utilities for interacting with the FBX SDK."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Tuple, TypeVar
+
+Vector3 = Tuple[float, float, float]
+T = TypeVar("T")
+
+
+def resolve_enum_value(enum_holder: Any, target_name: str) -> Any:
+    """Return an enum value by name, handling SDK layout differences.
+
+    Autodesk regularly shuffles where enumeration members live between
+    releases.  Sometimes they are attributes on the class, other times they
+    are nested under helper containers such as ``EType``.  This helper performs
+    a best-effort lookup so callers can request an enum using a friendly name
+    without needing to know the exact SDK flavour they are running against.
+    """
+
+    if hasattr(enum_holder, target_name):
+        return getattr(enum_holder, target_name)
+
+    for attr_name in dir(enum_holder):
+        if attr_name.lower() == target_name.lower():
+            return getattr(enum_holder, attr_name)
+
+    nested = getattr(enum_holder, "EType", None)
+    if nested is not None:
+        for attr_name in dir(nested):
+            if attr_name.lower() == target_name.lower():
+                return getattr(nested, attr_name)
+
+    raise AttributeError(
+        f"Unable to resolve enum value '{target_name}' from {enum_holder!r}"
+    )
+
+
+def double3_to_tuple(vector: Iterable[T]) -> Vector3:
+    """Convert FBX ``FbxDouble3`` style objects into a plain tuple."""
+
+    values = list(vector)
+    if len(values) != 3:
+        raise ValueError("Expected a 3 component vector.")
+    return (float(values[0]), float(values[1]), float(values[2]))
+


### PR DESCRIPTION
## Summary
- add shared FBX utility helpers and reuse them across inspectors and save operations
- streamline skeleton and scene graph inspectors with clearer docstrings and conversions
- refactor the GUI scene editor to centralize tree refresh logic and improve status handling

## Testing
- python -m compileall fbx_analyzer


------
https://chatgpt.com/codex/tasks/task_e_68dd9c2b4c108322ac4d5044fdeb5e22