### PR TITLE
Fix node transform serialization to use FbxDouble3

### DIFF
--- a/fbx_analyzer/core/save_as.py
+++ b/fbx_analyzer/core/save_as.py
@@ -162,6 +162,12 @@ def _apply_node_attribute(scene, node, attr_type: str, attr_class: str) -> None:
 
 
 def _apply_node_transform(node, model: SceneNode) -> None:  # type: ignore[valid-type]
-    node.LclTranslation.Set(*model.translation)
-    node.LclRotation.Set(*model.rotation)
-    node.LclScaling.Set(*model.scaling)
+    fbx, _ = sdk.import_fbx_module()
+
+    translation = fbx.FbxDouble3(*model.translation)
+    rotation = fbx.FbxDouble3(*model.rotation)
+    scaling = fbx.FbxDouble3(*model.scaling)
+
+    node.LclTranslation.Set(translation)
+    node.LclRotation.Set(rotation)
+    node.LclScaling.Set(scaling)


### PR DESCRIPTION
## Summary
- construct FbxDouble3 values before assigning translation, rotation, and scaling properties to nodes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd9e6498f88322b7f37502a1306818